### PR TITLE
Fixed an issue whereby the Java -> Ruby object mapping was duplicating k...

### DIFF
--- a/lib/jrjackson/rubify.rb
+++ b/lib/jrjackson/rubify.rb
@@ -22,8 +22,6 @@ module JrJackson
         v = deserialize(jp, ctxt)
         tmp.push(k)
         tmp.push(v)
-        tmp.push(k.to_sym)
-        tmp.push(v)
       end while jp.nextToken != JsonToken::END_OBJECT
       Hash[*tmp]
     end


### PR DESCRIPTION
...eys in the resulting hash: once as a String and once as a Symbol.

I removed the Symbol conversion to maintain parity with the JSON gem, which always works with Strings.
