### PR TITLE
Replace custom encoding logic with as_json

### DIFF
--- a/jrjackson.gemspec
+++ b/jrjackson.gemspec
@@ -2,7 +2,7 @@
 
 Gem::Specification.new do |s|
   s.name        = 'jrjackson'
-  s.version     = '0.1.1'
+  s.version     = '0.1.2'
   s.date        = '2013-04-03'
   s.platform    = Gem::Platform::RUBY
   s.authors     = ['Guy Boertje']

--- a/lib/jrjackson/jrjackson.rb
+++ b/lib/jrjackson/jrjackson.rb
@@ -8,8 +8,9 @@ require 'com/jrjackson/jr_jackson'
 
 module JrJackson
   module Json
-      class << self
+    class << self
       TIME_REGEX = %r(\A(\d{4}-\d\d-\d\d|(\w{3}\s){2}\d\d)\s\d\d:\d\d:\d\d)
+
       def load(json_string, options = {})
         mod = if options[:raw]
           JrJackson::Raw
@@ -26,22 +27,8 @@ module JrJackson
       end
 
       def dump(object)
-        case object
-        when Array, Hash
-          JrJackson::Raw.generate(object)
-        when String
-          "\"#{object}\""
-        when nil, true, false
-          object
-        else
-          if object.respond_to?(:to_json)
-            object.to_json
-          elsif object.respond_to?(:to_s)
-            object.to_s
-          else
-            object
-          end
-        end
+        object = object.as_json if object.respond_to?(:as_json)
+        JrJackson::Raw.generate(object)
       end
 
       alias :parse :load


### PR DESCRIPTION
In case of Strings the old method fails to escape nested (preescaped)
quotes, e.g.:

"CoffeeScript.compile.apply(this, [\"localStorage.setItem...\")"

was wrongly encoded as:

"\"CoffeeScript.compile.apply(this, [\"localStorage.setItem...\"])\""

Using the raw generator, we get the following result:

"\"CoffeeScript.compile.apply(this, [\\"localStorage.setItem...\\"])\""

The same applies to nil, true, false and the to_json/to_s fallback.

To simplify the encoding logic this commit uses the as_json convention
and relies on JrJackson::Raw to produce the correct output.
