### PR TITLE
Raw.generate for ArrayList too

### DIFF
--- a/lib/jrjackson/jrjackson.rb
+++ b/lib/jrjackson/jrjackson.rb
@@ -33,7 +33,7 @@ module JrJackson
 
       def dump(object)
         case object
-        when Hash, Array, String, Java::JavaUtil::LinkedHashMap, Java::JavaUtil::ArrayList
+        when Hash, Array, String, Java::JavaUtil::Map, Java::JavaUtil::List
           JrJackson::Raw.generate(object)
         when true, false
           object.to_s

--- a/test/jrjackson_test.rb
+++ b/test/jrjackson_test.rb
@@ -107,13 +107,16 @@ class JrJacksonTest < Test::Unit::TestCase
     # String
     assert_equal JrJackson::Json.dump("foo"), "\"foo\""
 
-    # Hash and LinkedHashMap
+    # Hash and implementations of the Java Hash interface
     assert_equal JrJackson::Json.dump({"foo" => 1}), "{\"foo\":1}"
+    assert_equal JrJackson::Json.dump(Java::JavaUtil::HashMap.new({"foo" => 1})), "{\"foo\":1}"
     assert_equal JrJackson::Json.dump(Java::JavaUtil::LinkedHashMap.new({"foo" => 1})), "{\"foo\":1}"
 
-    # Array and ArrayList
+    # Array and implementations of the Java List interface
     assert_equal JrJackson::Json.dump(["foo", 1]), "[\"foo\",1]"
     assert_equal JrJackson::Json.dump(Java::JavaUtil::ArrayList.new(["foo", 1])), "[\"foo\",1]"
+    assert_equal JrJackson::Json.dump(Java::JavaUtil::LinkedList.new(["foo", 1])), "[\"foo\",1]"
+    assert_equal JrJackson::Json.dump(Java::JavaUtil::Vector.new(["foo", 1])), "[\"foo\",1]"
 
     # true/false
     assert_equal JrJackson::Json.dump(true), "true"


### PR DESCRIPTION
`JrJackson::Json.dump` should use `JrJackson::Raw.generate` for `Java::JavaUtil::ArrayList`. 

I also included tests for all base object support in `JrJackson::Json.dump`. 

Before applying this fix, calling `dump` on `ArrayList` would return `to.s` of the  `ArrayList`:

``` ruby
JrJackson::Json.dump(Java::JavaUtil::ArrayList.new(["foo", 1])) #=> "[foo, 1]"
```

but what we want is `"[\"foo\", 1]"`.
