### PR TITLE
configurable date format in serialization

### DIFF
--- a/lib/jrjackson/jrjackson.rb
+++ b/lib/jrjackson/jrjackson.rb
@@ -31,10 +31,10 @@ module JrJackson
         end
       end
 
-      def dump(object)
+      def dump(object, options = {})
         case object
         when Array, Hash, String, Java::JavaUtil::LinkedHashMap
-          JrJackson::Raw.generate(object)
+          JrJackson::Raw.generate(object, options)
         when true, false
           object.to_s
         when nil

--- a/src/main/java/com/jrjackson/RubyJacksonModule.java
+++ b/src/main/java/com/jrjackson/RubyJacksonModule.java
@@ -49,8 +49,22 @@ public class RubyJacksonModule extends SimpleModule {
         return mapper;
     }
 
+    public static ObjectMapper serializerMapper(SimpleDateFormat format) {
+        ObjectMapper mapper = new ObjectMapper().registerModule(
+            new RubyJacksonModule().addSerializer(RubyObject.class, RubyAnySerializer.instance)
+        );
+        mapper.registerModule(new AfterburnerModule());
+        mapper.disable(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS);
+        mapper.setDateFormat(format);
+        return mapper;
+    }
+
+    public static ObjectMapper serializerMapper() {
+        return static_mapper;
+    }
+
     // public static SimpleModule asRaw()
-    // { 
+    // {
     //   return static_mapper;
     // }
     public static SimpleModule asSym(Ruby ruby) {

--- a/test/jrjackson_test.rb
+++ b/test/jrjackson_test.rb
@@ -9,6 +9,7 @@ require 'thread'
 require 'bigdecimal'
 require 'jrjackson'
 require 'stringio'
+require 'time'
 
 class JrJacksonTest < Test::Unit::TestCase
 
@@ -101,6 +102,22 @@ class JrJacksonTest < Test::Unit::TestCase
     }
     actual = JrJackson::Json.load(json_string, :symbolize_keys => true)
     assert_equal expected, actual
+  end
+
+  def test_serialize_date
+    # default date format
+    time_string = "2014-06-10 18:18:40 EDT"
+    time = Time.parse(time_string)
+    assert_equal "{\"time\":\"#{time_string}\"}", JrJackson::Json.dump({"time" => time})
+
+    # using date_format option
+    assert_equal "{\"time\":\"2014-06-10\"}", JrJackson::Json.dump({"time" => time}, :date_format => "yyyy-MM-dd")
+    assert_equal "{\"time\":\"2014-06-10T18:18:40.000-0400\"}", JrJackson::Json.dump({"time" => time}, :date_format => "yyyy-MM-dd'T'HH:mm:ss.SSSZ")
+
+    # using date_format and timezone options
+    assert_equal "{\"time\":\"2014-06-10T22:18:40.000+0000\"}", JrJackson::Json.dump({"time" => time}, :date_format => "yyyy-MM-dd'T'HH:mm:ss.SSSZ", :timezone => "UTC")
+    # iso8601 date_format and timezone
+    assert_equal "{\"time\":\"2014-06-10T22:18:40.000Z\"}", JrJackson::Json.dump({"time" => time}, :date_format => "yyyy-MM-dd'T'HH:mm:ss.SSSX", :timezone => "UTC")
   end
 
   def test_can_parse_nulls


### PR DESCRIPTION
`JrJackson::Json.dump` and `JrJackson::Raw.generate` now support an options Hash with the `date_format` and `timezone` options. 

- previous & default behaviour
```ruby
JrJackson::Json.dump({"time" => time})
#=> "{\"time\":\"2014-06-10 18:18:40 EDT\"}"
```
- with `date_format` options
```ruby
JrJackson::Json.dump({"time" => time}, :date_format => "yyyy-MM-dd'T'HH:mm:ss.SSSZ")
#=> "{\"time\":\"2014-06-10T18:18:40.000-0400\"}"
```

- with `date_format` and `timezone` options
```ruby
JrJackson::Json.dump({"time" => time}, :date_format => "yyyy-MM-dd'T'HH:mm:ss.SSSX", :timezone => "UTC")
#=> "{\"time\":\"2014-06-10T22:18:40.000Z\"}"
```

The `date_format` syntax is defined in `java.text.SimpleDateFormat` and the `timezone` in `java.util.TimeZone.getTimeZone()`

If you want to moveon with this, I can also add doc in the README file.