### PR TITLE
Special-case Struct to maintain to_a behavior in Ruby 2.0+ compat.

### DIFF
--- a/src/main/java/com/jrjackson/RubyAnySerializer.java
+++ b/src/main/java/com/jrjackson/RubyAnySerializer.java
@@ -93,6 +93,10 @@ public class RubyAnySerializer extends StdSerializer<RubyObject> {
             provider.findTypedValueSerializer(Map.class, true, null).serialize(value, jgen, provider);
         } else if (value instanceof RubyArray) {
             provider.findTypedValueSerializer(List.class, true, null).serialize(value, jgen, provider);
+        } else if (value instanceof RubyStruct) {
+            ThreadContext ctx = value.getRuntime().getCurrentContext();
+            RubyObject obj = (RubyObject)value.callMethod(ctx, "to_a");
+            provider.findTypedValueSerializer(List.class, true, null).serialize(obj, jgen, provider);
         } else {
             Object val = value.toJava(rubyJavaClassLookup(value.getClass()));
             if (val instanceof RubyObject) {


### PR DESCRIPTION
The current serialization logic does not handle Struct instances specially, allowing them to fall into the "unknown" serializer. That logic tries to call `to_h`, `to_hash`, `to_a`, etc in order on the given object until one of the coercions work. This allowed structs to serialize as an array of their values.

However, Ruby 2.0 (supported by JRuby 9k) added to_h to Struct, to get a hash representation of both keys and values. As a result, the jrjackson serializer now hits to_h for structs and inserts a hash into the resulting json instead of an array.

Assuming you want to keep the array behavior, this patch special-cases RubyStruct to always use to_a. If you aren't concerned about dispatching, it could call RubyStruct.to_a statically. If this is not the right fix, feel free to reject PR :-)
