### PR TITLE
Big integers fail to be parsed as Bignum

### DIFF
--- a/src/main/java/com/jrjackson/RubyObjectDeserializer.java
+++ b/src/main/java/com/jrjackson/RubyObjectDeserializer.java
@@ -78,7 +78,8 @@ public class RubyObjectDeserializer
                 /* [JACKSON-100]: caller may want to get all integral values
                  * returned as BigInteger, for consistency
                  */
-                if (ctxt.isEnabled(DeserializationFeature.USE_BIG_INTEGER_FOR_INTS)) {
+                JsonParser.NumberType numberType = jp.getNumberType();
+                if (ctxt.isEnabled(DeserializationFeature.USE_BIG_INTEGER_FOR_INTS) || numberType == JsonParser.NumberType.BIG_INTEGER) {
                     return RubyUtils.rubyBignum(_ruby, jp.getBigIntegerValue());
                 }
                 return RubyUtils.rubyFixnum(_ruby, jp.getLongValue());

--- a/test/jrjackson_test.rb
+++ b/test/jrjackson_test.rb
@@ -146,6 +146,14 @@ class JrJacksonTest < Test::Unit::TestCase
     end
   end
 
+  def test_can_parse_bignum
+    expected = 12345678901234567890123456789
+    json = '{"foo":12345678901234567890123456789}'
+
+    actual = JrJackson::Json.parse(json)['foo']
+    assert_equal expected, actual
+  end
+
   def test_can_parse_big_decimals
     expected = BigDecimal.new '0.12345678901234567890123456789'
     json = '{"foo":0.12345678901234567890123456789}'


### PR DESCRIPTION
Fails with error
    Numeric value (12345678901234567890123456789) out of range of long (-9223372036854775808 - 9223372036854775807)

Test included, I haven't updated the jar file because I don't have java 6 installed and I wasn't exactly sure if it was just copied over
