### PR TITLE
Bump Jackson to v2.9.4 to resolve CVE-2017-15095 et al

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,7 @@ Rakefile.old
 linked
 /libyjpagent.so
 /.project
+
+lib/jrjackson_jars.rb
+lib/com/fasterxml/jackson/
+pom.xml

--- a/.gitignore
+++ b/.gitignore
@@ -11,4 +11,5 @@ linked
 
 lib/jrjackson_jars.rb
 lib/com/fasterxml/jackson/
+lib/jrjackson/jars/jrjackson-*.jar
 pom.xml

--- a/jrjackson.gemspec
+++ b/jrjackson.gemspec
@@ -27,5 +27,4 @@ Gem::Specification.new do |s|
   s.requirements << "jar com.fasterxml.jackson.module:jackson-module-afterburner, #{jackson_version}"
 
   s.files = JrJackson::BuildInfo.files
-
 end

--- a/lib/jrjackson/build_info.rb
+++ b/lib/jrjackson/build_info.rb
@@ -1,23 +1,33 @@
 module JrJackson
   module BuildInfo
     def self.version
-      '0.4.4'
+      '0.4.5'
     end
 
     def self.release_date
-      '2017-10-06'
+      '2018-02-17'
     end
 
     def self.files
-      `git ls-files`.split($/).select{|f| f !~ /\Abenchmarking/}
+      generated_files.concat(git_files)
     end
 
     def self.jackson_version
-      '2.9.1'
+      '2.9.4'
     end
 
     def self.jar_version
-      '1.2.22'
+      '1.2.23'
+    end
+
+    private
+
+    def self.generated_files
+      Dir.glob( %w(pom.xml lib/jrjackson_jars.rb lib/com/fasterxml/jackson/**/*.jar lib/jrjackson/jars/jrjackson-*.jar) )
+    end
+
+    def self.git_files
+      `git ls-files`.split($/).reject{|s| s.start_with?("benchmarking")}
     end
   end
 end


### PR DESCRIPTION
Thanks to @alex-dr for #66 

> Deletes old versions of jackson from the  repository so they don't get included in the final artifact or show up on security scans. I really am not very comfortable with how this repo checks in binaries; I grabbed these from mvnrepository.com, but the author or any other contributor could have injected their own binaries with any malicious code they want and 99.999% of consumers (read; everyone running Logstash) would never know. For context on upstream fix, see: https://bugzilla.redhat.com/show_bug.cgi?id=1506612 CVE-2017-17485: FasterXML/jackson-databind#1855 CVE-2018-5968: FasterXML/jackson-databind#1899
--

The binaries and package only files are now not committed to the repo.
They will be packaged into the gem and pushed to rubygems by the author. 


