### PR TITLE
JRuby 9.2 compatibility fixes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@ target
 Rakefile.old
 .idea
 *.iml
+.ruby-version
 
 linked
 /libyjpagent.so

--- a/Mavenfile
+++ b/Mavenfile
@@ -14,7 +14,7 @@ properties 'project.build.sourceEncoding' => 'UTF-8',
 
 jar 'junit:junit', '4.11', :scope => :test
 
-jar 'org.jruby:jruby', '9.1.13.0', :scope => :provided
+jar 'org.jruby:jruby', '9.2.0.0', :scope => :provided
 
 plugin :compiler, '3.1', :source => '1.8', :target => '1.8',
        :showDeprecation => false,

--- a/run_all_individual_bench.sh
+++ b/run_all_individual_bench.sh
@@ -3,23 +3,23 @@
 chruby-exec ruby-2.2.2 -- ruby benchmarking/individual/json-mri-sourced.rb
 chruby-exec ruby-2.2.2 -- ruby benchmarking/individual/oj-mri-sourced.rb
 
-chruby-exec jruby-9.0.0.0.rc1 -- ruby -J-Xmn512m -J-Xms2048m -J-Xmx2048m benchmarking/individual/gson-jr-sourced.rb
-chruby-exec jruby-9.0.0.0.rc1 -- ruby -J-Xmn512m -J-Xms2048m -J-Xmx2048m benchmarking/individual/json-jr-sourced.rb
+chruby-exec jruby-9.2.0.0 -- ruby -J-Xmn512m -J-Xms2048m -J-Xmx2048m benchmarking/individual/gson-jr-sourced.rb
+chruby-exec jruby-9.2.0.0 -- ruby -J-Xmn512m -J-Xms2048m -J-Xmx2048m benchmarking/individual/json-jr-sourced.rb
 
-chruby-exec jruby-9.0.0.0.rc1 -- ruby -J-Xmn512m -J-Xms2048m -J-Xmx2048m benchmarking/individual/string-jr-sourced.rb
-chruby-exec jruby-9.0.0.0.rc1 -- ruby -J-Xmn512m -J-Xms2048m -J-Xmx2048m benchmarking/individual/str-bd-jr-sourced.rb
+chruby-exec jruby-9.2.0.0 -- ruby -J-Xmn512m -J-Xms2048m -J-Xmx2048m benchmarking/individual/string-jr-sourced.rb
+chruby-exec jruby-9.2.0.0 -- ruby -J-Xmn512m -J-Xms2048m -J-Xmx2048m benchmarking/individual/str-bd-jr-sourced.rb
 
-chruby-exec jruby-9.0.0.0.rc1 -- ruby -J-Xmn512m -J-Xms2048m -J-Xmx2048m benchmarking/individual/symbol-jr-sourced.rb
-chruby-exec jruby-9.0.0.0.rc1 -- ruby -J-Xmn512m -J-Xms2048m -J-Xmx2048m benchmarking/individual/sym-bd-jr-sourced.rb
+chruby-exec jruby-9.2.0.0 -- ruby -J-Xmn512m -J-Xms2048m -J-Xmx2048m benchmarking/individual/symbol-jr-sourced.rb
+chruby-exec jruby-9.2.0.0 -- ruby -J-Xmn512m -J-Xms2048m -J-Xmx2048m benchmarking/individual/sym-bd-jr-sourced.rb
 
-chruby-exec jruby-9.0.0.0.rc1 -- ruby -J-Xmn512m -J-Xms2048m -J-Xmx2048m benchmarking/individual/raw-jr-sourced.rb
-chruby-exec jruby-9.0.0.0.rc1 -- ruby -J-Xmn512m -J-Xms2048m -J-Xmx2048m benchmarking/individual/raw-bd-jr-sourced.rb
+chruby-exec jruby-9.2.0.0 -- ruby -J-Xmn512m -J-Xms2048m -J-Xmx2048m benchmarking/individual/raw-jr-sourced.rb
+chruby-exec jruby-9.2.0.0 -- ruby -J-Xmn512m -J-Xms2048m -J-Xmx2048m benchmarking/individual/raw-bd-jr-sourced.rb
 
-chruby-exec jruby-9.0.0.0.rc1 -- ruby -J-Xmn512m -J-Xms2048m -J-Xmx2048m benchmarking/individual/sj-jr-sourced.rb
+chruby-exec jruby-9.2.0.0 -- ruby -J-Xmn512m -J-Xms2048m -J-Xmx2048m benchmarking/individual/sj-jr-sourced.rb
 
 chruby-exec ruby-2.2.2 -- ruby benchmarking/individual/json-gen-mri-sourced.rb
 chruby-exec ruby-2.2.2 -- ruby benchmarking/individual/oj-gen-mri-sourced.rb
 
-chruby-exec jruby-9.0.0.0.rc1 -- ruby -J-Xmn512m -J-Xms2048m -J-Xmx2048m benchmarking/individual/json-gen-jr-sourced.rb 
-chruby-exec jruby-9.0.0.0.rc1 -- ruby -J-Xmn512m -J-Xms2048m -J-Xmx2048m benchmarking/individual/gson-gen-jr-sourced.rb 
-chruby-exec jruby-9.0.0.0.rc1 -- ruby -J-Xmn512m -J-Xms2048m -J-Xmx2048m benchmarking/individual/raw-gen-jr-sourced.rb 
+chruby-exec jruby-9.2.0.0 -- ruby -J-Xmn512m -J-Xms2048m -J-Xmx2048m benchmarking/individual/json-gen-jr-sourced.rb
+chruby-exec jruby-9.2.0.0 -- ruby -J-Xmn512m -J-Xms2048m -J-Xmx2048m benchmarking/individual/gson-gen-jr-sourced.rb
+chruby-exec jruby-9.2.0.0 -- ruby -J-Xmn512m -J-Xms2048m -J-Xmx2048m benchmarking/individual/raw-gen-jr-sourced.rb

--- a/src/main/java/com/jrjackson/RubyAnySerializer.java
+++ b/src/main/java/com/jrjackson/RubyAnySerializer.java
@@ -173,6 +173,7 @@ public class RubyAnySerializer extends JsonSerializer<IRubyObject> {
                 jgen.writeNumber(RubyNumeric.num2dbl(value));
                 break;
             case Fixnum:
+            case Integer:
                 jgen.writeNumber(RubyNumeric.num2long(value));
                 break;
             case Bignum:
@@ -265,6 +266,7 @@ public class RubyAnySerializer extends JsonSerializer<IRubyObject> {
     enum RUBYCLASS {
         String,
         Fixnum,
+        Integer,
         Hash,
         Array,
         Float,

--- a/src/main/java/com/jrjackson/RubyJacksonModule.java
+++ b/src/main/java/com/jrjackson/RubyJacksonModule.java
@@ -12,11 +12,9 @@ import org.jruby.Ruby;
 import org.jruby.runtime.builtin.IRubyObject;
 
 import java.text.SimpleDateFormat;
+import java.util.TimeZone;
 
 public class RubyJacksonModule extends SimpleModule {
-
-    private static final SimpleDateFormat RDF = new RubyDateFormat("yyyy-MM-dd HH:mm:ss Z");
-
     public static final ObjectMapper static_mapper = new ObjectMapper();
     public static final JsonFactory factory = new JsonFactory(static_mapper).disable(JsonFactory.Feature.FAIL_ON_SYMBOL_HASH_OVERFLOW);
 
@@ -56,11 +54,9 @@ public class RubyJacksonModule extends SimpleModule {
     }
 
     public static DefaultSerializerProvider createProvider() {
-        static_mapper.setDateFormat(RDF);
-        return ((DefaultSerializerProvider) static_mapper.getSerializerProvider()).createInstance(
-                static_mapper.getSerializationConfig(),
-                static_mapper.getSerializerFactory()
-        );
+        SimpleDateFormat rdf = new SimpleDateFormat("yyyy-MM-dd HH:mm:ss Z");
+        rdf.setTimeZone(TimeZone.getTimeZone("UTC"));
+        return createProvider(rdf);
     }
 
     public static ObjectMapper rawBigNumberMapper() {

--- a/test/jrjackson_test.rb
+++ b/test/jrjackson_test.rb
@@ -340,7 +340,7 @@ class JrJacksonTest < Test::Unit::TestCase
     time = Time.new(2014,6,10,18,18,40, "-04:00")
     # using date_format option
     assert_equal "{\"time\":\"2014-06-10\"}", JrJackson::Json.dump({"time" => time}, :date_format => "yyyy-MM-dd")
-    assert_match /\{"time"\:"\d{4}-\d\d-\d\dT\d\d:\d\d:\d\d\.\d{3}[+-]\d{4}"\}/, JrJackson::Json.dump({"time" => time}, :date_format => "yyyy-MM-dd'T'HH:mm:ss.SSSZ")
+    assert_match(/\{"time"\:"\d{4}-\d\d-\d\dT\d\d:\d\d:\d\d\.\d{3}[+-]\d{4}"\}/, JrJackson::Json.dump({"time" => time}, :date_format => "yyyy-MM-dd'T'HH:mm:ss.SSSZ"))
   end
 
   def test_serialize_date_date_format_timezone
@@ -370,7 +370,7 @@ class JrJacksonTest < Test::Unit::TestCase
     assert_equal "żółć", actual["utf8"]
     assert_equal Java::JavaUtil::HashMap, actual["zzz"].class
     assert_equal Bignum, actual["zzz"]["bar"].class
-    assert_equal -9, actual["zzz"]["bar"]
+    assert_equal(-9, actual["zzz"]["bar"])
   end
 
   def test_can_parse_returning_ruby_objects_string_keys
@@ -451,7 +451,7 @@ class JrJacksonTest < Test::Unit::TestCase
   end
 
   def test_can_parse_big_decimals
-    expected = BigDecimal.new '0.12345678901234567890123456789'
+    expected = BigDecimal('0.12345678901234567890123456789')
     json = '{"foo":0.12345678901234567890123456789}'
 
     actual = JrJackson::Json.parse(json, :use_bigdecimal => true)['foo']
@@ -546,7 +546,7 @@ class JrJacksonTest < Test::Unit::TestCase
   end
 
   def assert_bigdecimal_similar(expected, actual)
-    assert_equal BigDecimal.new(expected.to_s).round(11), BigDecimal.new(actual.to_s).round(11)
+    assert_equal BigDecimal(expected.to_s).round(11), BigDecimal(actual.to_s).round(11)
     assert_equal Java::JavaMath::BigDecimal, actual.class
   end
 end

--- a/test/jrjackson_test.rb
+++ b/test/jrjackson_test.rb
@@ -70,7 +70,7 @@ class JrJacksonTest < Test::Unit::TestCase
       @now = tm
     end
     def to_time
-      @now.to_time
+      @now.to_time.utc
     end
   end
 
@@ -281,7 +281,7 @@ class JrJacksonTest < Test::Unit::TestCase
   end
 
   def test_serialize_non_json_datatypes_as_values
-    dt = Time.now
+    dt = Time.now.utc
     today = Date.today
     co1 = CustomToH.new("uno", :two, 6.0)
     co2 = CustomToHash.new("uno", :two, 6.0)
@@ -292,12 +292,12 @@ class JrJacksonTest < Test::Unit::TestCase
     json_string = JrJackson::Json.dump(source)
     expected = {
       :sym => "a_symbol",
-      :dt => dt.to_s,
+      :dt => dt.strftime('%F %T %z'),
       :co1 => {:one => "uno", :two => "two", :six => 6.0 },
       :co2 => {:one => "uno", :two => "two", :six => 6.0 },
       :co3 => {:one => 1.0, :two => 2.0, :six => 6.0 },
       :co4 => [1, 2, 6],
-      :co5 => today.to_time.to_s
+      :co5 => today.to_time.utc.strftime('%F %T %z')
     }
     actual = JrJackson::Json.load(json_string, :symbolize_keys => true)
     assert_equal expected, actual
@@ -514,7 +514,7 @@ class JrJacksonTest < Test::Unit::TestCase
 
   def test_can_mix_java_and_ruby_objects
     json = '{"utf8":"żółć", "moo": "bar", "arr": [2,3,4], "flo": 3.33}'
-    timeobj = Time.new(2015,11,11,11,11,11).utc
+    timeobj = Time.new(2015,11,11,11,11,11,0).utc
     expected = '{"mixed":{"arr":[2,3,4],"utf8":"żółć","flo":3.33,"zzz":{"one":1.0,"two":2,"six":6.0},"moo":"bar"},"time":"2015-11-11 11:11:11 +0000"}'
     object = JrJackson::Json.parse_java(json)
     object["zzz"] = CustomToJson.new(1.0, 2, 6.0)


### PR DESCRIPTION
Fixes #69 and updates base build version for JRuby to 9.2.0.0.  Commit 89c2ac6 also sets a consistent default date format with UTC time zone, and fixes a couple of tests that were also failing in JRuby 9.0 due to timezone issues.  (I suspect the tests only passed on a machine whose operating system was set to UTC.)

Please let me know if any further work is needed to make this suitable for merge.  Thank you!