### PR TITLE
jrjackson fails to parse valid JSON in UTF-16 and UTF-32

### DIFF
--- a/test/jrjackson_test.rb
+++ b/test/jrjackson_test.rb
@@ -468,6 +468,24 @@ class JrJacksonTest < Test::Unit::TestCase
 
   end
 
+  def test_can_parse_utf_16
+    expected = { "key" => "value👍" }
+    json_utf_16 = '{"key": "value👍"}'.encode('UTF-16')
+
+    actual = JrJackson::Json.load(json_utf_16)
+
+    assert_equal(expected, actual)
+  end
+
+  def test_can_parse_utf_32
+    expected = { "key" => "value👍" }
+    json_utf_32 = '{"key": "value👍"}'.encode('UTF-32')
+
+    actual = JrJackson::Json.load(json_utf_32)
+
+    assert_equal(expected, actual)
+  end
+
   def test_can_serialize_object
     obj = Object.new
     actual = JrJackson::Json.dump({"foo" => obj})


### PR DESCRIPTION
> 8.1.  Character Encoding
>
>    JSON text SHALL be encoded in UTF-8, UTF-16, or UTF-32.  The default
>    encoding is UTF-8, and JSON texts that are encoded in UTF-8 are
>    interoperable in the sense that they will be read successfully by the
>    maximum number of implementations; there are many implementations
>    that cannot successfully read texts in other encodings (such as
>    UTF-16 and UTF-32).
>
> -- [RFC7159 §8.1](https://tools.ietf.org/html/rfc7159)