### PR TITLE
Fix concurrency issues

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -10,7 +10,7 @@ end
 
 desc "Run benchmarks"
 task :benchmark do
-  load 'benchmarking/benchmark.rb'
+  load 'benchmarking/benchmark_threaded.rb'
 end
 
 desc "Pack jar after compiling classes, use this to rebuild the pom.xml"

--- a/benchmarking/benchmark_threaded.rb
+++ b/benchmarking/benchmark_threaded.rb
@@ -87,8 +87,10 @@ Benchmark.bmbm("Jackson generate with no dates".size) do |x|
   x.report("Jackson generate with dates") do
     threads = 100.times.map do
       Thread.new do
-        org_array.each do |hsh|
-          JrJackson::Base.generate(hsh)
+        10.times.each do
+          org_array.each do |hsh|
+            JrJackson::Base.generate(hsh)
+          end
         end
       end
     end
@@ -99,8 +101,10 @@ Benchmark.bmbm("Jackson generate with no dates".size) do |x|
 
     threads = 100.times.map do
       Thread.new do
-        no_dates_array.each do |hsh|
-          JrJackson::Base.generate(hsh)
+        10.times.each do
+          no_dates_array.each do |hsh|
+            JrJackson::Base.generate(hsh)
+          end
         end
       end
     end

--- a/changelog.md
+++ b/changelog.md
@@ -1,3 +1,7 @@
+v0.4.10
+  fix concurrency issue when serializing dates. Also cache the value of "UTC" TimeZone locally to 
+  avoid contention to synchronized `getTimeZone` method.
+
 v0.4.9
   bump Jackson to v2.9.9, and jackson-databind to v2.9.9.3
 

--- a/changelog.md
+++ b/changelog.md
@@ -1,6 +1,10 @@
 v0.4.10
-  fix concurrency issue when serializing dates. Also cache the value of "UTC" TimeZone locally to 
-  avoid contention to synchronized `getTimeZone` method.
+  fix concurrency issue when serializing dates. 
+  Cache UTC TimeZone class to avoid unnecessary calls to synchronized method
+  Use a ThreadLocal to hold per-thread instances of SimpleDateFormat to avoid
+   unnecessary expensive clonings of that object
+  Replace unsafe call to setDateFormat on static ObjectMapper class by creating
+   an amended SerializationConfig
 
 v0.4.9
   bump Jackson to v2.9.9, and jackson-databind to v2.9.9.3

--- a/lib/jrjackson/build_info.rb
+++ b/lib/jrjackson/build_info.rb
@@ -5,7 +5,7 @@ module JrJackson
     end
 
     def self.release_date
-      '2019-09-24'
+      '2019-09-25'
     end
 
     def self.files
@@ -21,7 +21,7 @@ module JrJackson
     end
 
     def self.jar_version
-      '1.2.27'
+      '1.2.28'
     end
 
     private

--- a/lib/jrjackson/build_info.rb
+++ b/lib/jrjackson/build_info.rb
@@ -1,11 +1,11 @@
 module JrJackson
   module BuildInfo
     def self.version
-      '0.4.9'
+      '0.4.10'
     end
 
     def self.release_date
-      '2019-08-09'
+      '2019-09-24'
     end
 
     def self.files

--- a/src/main/java/com/jrjackson/RubyAnySerializer.java
+++ b/src/main/java/com/jrjackson/RubyAnySerializer.java
@@ -238,8 +238,8 @@ public class RubyAnySerializer extends JsonSerializer<IRubyObject> {
         else if (df instanceof RubyDateFormat) {
             // why another branch? I thought there was an easy win on to_s
             // maybe with jruby 9000
-            RubyDateFormat clonedRubyDatFormat = (RubyDateFormat) df.clone();
-            jgen.writeString(clonedRubyDatFormat.format(dt.getJavaDate()));
+            RubyDateFormat clonedRubyDateFormat = (RubyDateFormat) df.clone();
+            jgen.writeString(clonedRubyDateFormat.format(dt.getJavaDate()));
         } else {
             jgen.writeString(df.format(dt.getJavaDate()));
         }

--- a/src/main/java/com/jrjackson/RubyAnySerializer.java
+++ b/src/main/java/com/jrjackson/RubyAnySerializer.java
@@ -237,11 +237,11 @@ public class RubyAnySerializer extends JsonSerializer<IRubyObject> {
         } else if (df instanceof RubyDateFormat) {
             // why another branch? I thought there was an easy win on to_s
             // maybe with jruby 9000
-            RubyDateFormat rdf = (RubyDateFormat) df.clone();
-            jgen.writeString(rdf.format(dt.getJavaDate()));
+            RubyDateFormat clonedRubyDatFormat = (RubyDateFormat) df.clone();
+            jgen.writeString(clonedRubyDatFormat.format(dt.getJavaDate()));
         } else {
-            SimpleDateFormat sdf = (SimpleDateFormat) df.clone();
-            jgen.writeString(df.format(dt.getJavaDate()));
+            SimpleDateFormat clonedSimpleDateFormat = (SimpleDateFormat) df.clone();
+            jgen.writeString(clonedSimpleDateFormat.format(dt.getJavaDate()));
         }
     }
 

--- a/src/main/java/com/jrjackson/RubyAnySerializer.java
+++ b/src/main/java/com/jrjackson/RubyAnySerializer.java
@@ -234,14 +234,14 @@ public class RubyAnySerializer extends JsonSerializer<IRubyObject> {
         if (df == null) {
             // DateFormat should always be set
             provider.defaultSerializeDateValue(dt.getJavaDate(), jgen);
-        } else if (df instanceof RubyDateFormat) {
+        } // RWB Note: I believe this is no longer used
+        else if (df instanceof RubyDateFormat) {
             // why another branch? I thought there was an easy win on to_s
             // maybe with jruby 9000
             RubyDateFormat clonedRubyDatFormat = (RubyDateFormat) df.clone();
             jgen.writeString(clonedRubyDatFormat.format(dt.getJavaDate()));
         } else {
-            SimpleDateFormat clonedSimpleDateFormat = (SimpleDateFormat) df.clone();
-            jgen.writeString(clonedSimpleDateFormat.format(dt.getJavaDate()));
+            jgen.writeString(df.format(dt.getJavaDate()));
         }
     }
 

--- a/src/main/java/com/jrjackson/RubyJacksonModule.java
+++ b/src/main/java/com/jrjackson/RubyJacksonModule.java
@@ -17,6 +17,7 @@ import java.util.TimeZone;
 public class RubyJacksonModule extends SimpleModule {
     public static final ObjectMapper static_mapper = new ObjectMapper();
     public static final JsonFactory factory = new JsonFactory(static_mapper).disable(JsonFactory.Feature.FAIL_ON_SYMBOL_HASH_OVERFLOW);
+    private static final TimeZone utcTimeZone = TimeZone.getTimeZone("UTC");
 
     static {
         static_mapper.registerModule(new RubyJacksonModule().addSerializer(
@@ -55,7 +56,7 @@ public class RubyJacksonModule extends SimpleModule {
 
     public static DefaultSerializerProvider createProvider() {
         SimpleDateFormat rdf = new SimpleDateFormat("yyyy-MM-dd HH:mm:ss Z");
-        rdf.setTimeZone(TimeZone.getTimeZone("UTC"));
+        rdf.setTimeZone(utcTimeZone);
         return createProvider(rdf);
     }
 

--- a/src/main/java/com/jrjackson/RubyJacksonModule.java
+++ b/src/main/java/com/jrjackson/RubyJacksonModule.java
@@ -5,6 +5,7 @@ import com.fasterxml.jackson.core.Version;
 import com.fasterxml.jackson.databind.DeserializationFeature;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.SerializationFeature;
+import com.fasterxml.jackson.databind.SerializationConfig;
 import com.fasterxml.jackson.databind.module.SimpleModule;
 import com.fasterxml.jackson.databind.ser.DefaultSerializerProvider;
 import com.fasterxml.jackson.module.afterburner.AfterburnerModule;
@@ -19,6 +20,15 @@ public class RubyJacksonModule extends SimpleModule {
     public static final JsonFactory factory = new JsonFactory(static_mapper).disable(JsonFactory.Feature.FAIL_ON_SYMBOL_HASH_OVERFLOW);
     private static final TimeZone utcTimeZone = TimeZone.getTimeZone("UTC");
 
+    private static final ThreadLocal<SimpleDateFormat>  dateFormat = new ThreadLocal<SimpleDateFormat> ()  {
+        @Override
+        protected SimpleDateFormat initialValue() {
+            SimpleDateFormat rdf = new SimpleDateFormat("yyyy-MM-dd HH:mm:ss Z");
+            rdf.setTimeZone(utcTimeZone);
+            return rdf;
+        }
+    };
+
     static {
         static_mapper.registerModule(new RubyJacksonModule().addSerializer(
                 IRubyObject.class, RubyAnySerializer.instance
@@ -28,7 +38,7 @@ public class RubyJacksonModule extends SimpleModule {
     }
 
     private RubyJacksonModule() {
-        super("JrJacksonStrModule", new Version(1, 2, 18, "0", "com.jrjackson.jruby", "jrjackson"));
+        super("JrJacksonStrModule", new Version(1, 2, 28, "0", "com.jrjackson.jruby", "jrjackson"));
     }
 
     public static ObjectMapper mapperWith(Ruby ruby, RubyKeyConverter nameConverter,
@@ -47,17 +57,18 @@ public class RubyJacksonModule extends SimpleModule {
     }
 
     public static DefaultSerializerProvider createProvider(SimpleDateFormat sdf) {
-        static_mapper.setDateFormat(sdf);
+        // Use a copy of the SerializationConfig to avoid calling setDateFormat on the static ObjectMapper
+        // object, removing its thread safety properties. In future, we might want to think about doing
+        // a refactor to use ObjectWriters instead of modifying serialization configs.
+        SerializationConfig config = static_mapper.getSerializationConfig().with(sdf);
         return ((DefaultSerializerProvider) static_mapper.getSerializerProvider()).createInstance(
-                static_mapper.getSerializationConfig(),
+                config,
                 static_mapper.getSerializerFactory()
         );
     }
 
     public static DefaultSerializerProvider createProvider() {
-        SimpleDateFormat rdf = new SimpleDateFormat("yyyy-MM-dd HH:mm:ss Z");
-        rdf.setTimeZone(utcTimeZone);
-        return createProvider(rdf);
+        return createProvider(dateFormat.get());
     }
 
     public static ObjectMapper rawBigNumberMapper() {

--- a/test/jrjackson_test.rb
+++ b/test/jrjackson_test.rb
@@ -548,6 +548,21 @@ class JrJacksonTest < Test::Unit::TestCase
     assert_equal "{\"foo\":9223372036854775808,\"bar\":65536}", actual
   end
 
+
+  # This test failed more often than not before fixing the underlying code
+  # and would fail every time if `100_000.times` was changed to `loop`
+  def test_concurrent_dump
+    now = Time.now
+    num_threads = 100
+
+    threads = num_threads.times.map do |i|
+      Thread.new do
+        100_000.times { JrJackson::Json.dump("a" => now) }
+      end
+    end
+    threads.each(&:join)
+  end
+
   # -----------------------------
 
   def assert_bigdecimal_equal(expected, actual)


### PR DESCRIPTION
Fixes ArrayIndexOutOfBoundsException that can occur when serializing dates concurrently.
Also cache the value of "UTC" TimeZone locally to avoid contention to synchronized
`getTimeZone` method.

Fixes #76, #77