### PR TITLE
Bump jackson databind to 2.9.10.8

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,3 +1,6 @@
+v0.4.14
+  Bump jackson-databind to v2.9.10.8
+
 v0.4.13
   Bump jackson-databind to v2.9.10.6
 
@@ -8,7 +11,7 @@ v0.4.11
   Bump Jackson to v2.9.10, and jackson-databind to v2.9.10.1
 
 v0.4.10
-  fix concurrency issue when serializing dates. 
+  fix concurrency issue when serializing dates.
   Cache UTC TimeZone class to avoid unnecessary calls to synchronized method
   Use a ThreadLocal to hold per-thread instances of SimpleDateFormat to avoid
    unnecessary expensive clonings of that object
@@ -19,7 +22,7 @@ v0.4.9
   bump Jackson to v2.9.9, and jackson-databind to v2.9.9.3
 
 v0.4.8
-  fix serialisation of big numbers as Ruby 2.4 unifies Fixnum and Bignum into Integer 
+  fix serialisation of big numbers as Ruby 2.4 unifies Fixnum and Bignum into Integer
 
 v0.4.4
   fix for issue 64
@@ -28,7 +31,7 @@ v0.4.4
 v0.4.3
   bump Jackson to v2.9.1
   make static_mapper public
-  
+
 v0.4.1
   fix for issue 55
     Refactor AnySerializer acceptable class detection that does not use an exception

--- a/lib/jrjackson/build_info.rb
+++ b/lib/jrjackson/build_info.rb
@@ -1,11 +1,11 @@
 module JrJackson
   module BuildInfo
     def self.version
-      '0.4.13'
+      '0.4.14'
     end
 
     def self.release_date
-      '2020-10-26'
+      '2021-01-06'
     end
 
     def self.files
@@ -17,11 +17,11 @@ module JrJackson
     end
 
     def self.jackson_databind_version
-      '2.9.10.6'
+      '2.9.10.8'
     end
 
     def self.jar_version
-      '1.2.31'
+      '1.2.32'
     end
 
     private


### PR DESCRIPTION
jackson-databind [2.9.10.8 + 2.9.10.7 release notes](https://github.com/FasterXML/jackson-databind/compare/jackson-databind-2.9.10.6...jackson-databind-2.9.10.8#diff-aab54890459ccf912fe63304ffcde5cc5a4dd6fecb795a10ec4b3e9fd56a59d8R7-R29)