### PR TITLE
Build: bump jruby + move vendoring to rake

### DIFF
--- a/Mavenfile
+++ b/Mavenfile
@@ -14,7 +14,7 @@ properties 'project.build.sourceEncoding' => 'UTF-8',
 
 jar 'junit:junit', '4.11', :scope => :test
 
-jar 'org.jruby:jruby', '9.2.4.0', :scope => :provided
+jar 'org.jruby:jruby', '9.2.13.0', :scope => :provided
 
 plugin :compiler, '3.1', :source => '1.8', :target => '1.8',
        :showDeprecation => false,
@@ -23,9 +23,3 @@ plugin :compiler, '3.1', :source => '1.8', :target => '1.8',
        :fork => true
 
 plugin :surefire, '2.17', :skipTests => true
-
-# since bundle install does not vendor our jars we need to it manually
-plugin 'org.torquebox.mojo:jruby9-exec-maven-plugin', '0.3.1' do
-  execute_goal :exec, :id => 'vendor-jars', :phase => 'prepare-package',
-               :script => "require 'jars/installer';Jars::Installer.vendor_jars!"
-end

--- a/Rakefile
+++ b/Rakefile
@@ -16,6 +16,13 @@ end
 desc "Pack jar after compiling classes, use this to rebuild the pom.xml"
 task :compile do
   RubyMaven.exec('prepare-package')
+  # after packaging the jrjackson-x.y.z.jar vendor jar dependencies
+  Rake::Task['vendor_jars'].invoke
+end
+
+task :vendor_jars do
+  require 'jars/installer'
+  Jars::Installer.vendor_jars!
 end
 
 desc "Clean build"
@@ -30,4 +37,3 @@ Gem::PackageTask.new( eval File.read( 'jrjackson.gemspec' ) ) do
   desc 'Pack gem'
   task :package => [:compile]
 end
-

--- a/jrjackson.gemspec
+++ b/jrjackson.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |s|
   s.license     = 'Apache License 2.0'
   s.require_paths = ["lib"]
 
-  s.add_development_dependency 'bundler', '~> 1.10'
+  s.add_development_dependency 'bundler'
   s.add_development_dependency 'jar-dependencies', '< 2.0', '>= 0.3.2'
 
   jackson_version = JrJackson::BuildInfo.jackson_version


### PR DESCRIPTION
moved task replicates the mvn after prepare-package behavior

updated jruby 9.2 seems to have issues installing ruby-maven :
```
[INFO] --- maven-jar-plugin:2.4:jar (default) @ jrjackson ---
[INFO] Building jar:
/home/kares/workspace/oss/jrjackson/lib/jrjackson/jars/jrjackson-1.2.32.jar
[INFO]
[INFO] --- jruby9-exec-maven-plugin:0.3.1:exec (vendor-jars) @ jrjackson
---
[INFO] Installing gem 'ruby-maven' . . .
[INFO] RuntimeError: there was an error installing 'ruby-maven (~>
3.3.11)' . please install it manually:
requested 'ruby-maven (~> 3.3.11)'>
[INFO]                 install_gem at
/home/kares/workspace/oss/jrjackson/pkg/rubygems-test/gems/jar-dependencies-0.4.1/lib/jars/maven_factory.rb:130
[INFO]        add_gem_to_load_path at
/home/kares/workspace/oss/jrjackson/pkg/rubygems-test/gems/jar-dependencies-0.4.1/lib/jars/maven_factory.rb:104
[INFO]             lazy_load_maven at
/home/kares/workspace/oss/jrjackson/pkg/rubygems-test/gems/jar-dependencies-0.4.1/lib/jars/maven_factory.rb:78
[INFO]                   maven_new at
/home/kares/workspace/oss/jrjackson/pkg/rubygems-test/gems/jar-dependencies-0.4.1/lib/jars/maven_factory.rb:45
[INFO]   resolve_dependencies_list at
/home/kares/workspace/oss/jrjackson/pkg/rubygems-test/gems/jar-dependencies-0.4.1/lib/jars/maven_exec.rb:66
[INFO]        install_dependencies at
/home/kares/workspace/oss/jrjackson/pkg/rubygems-test/gems/jar-dependencies-0.4.1/lib/jars/installer.rb:233
[INFO]                  do_install at
/home/kares/workspace/oss/jrjackson/pkg/rubygems-test/gems/jar-dependencies-0.4.1/lib/jars/installer.rb:224
[INFO]                vendor_jars! at
/home/kares/workspace/oss/jrjackson/pkg/rubygems-test/gems/jar-dependencies-0.4.1/lib/jars/installer.rb:179
[INFO]                vendor_jars! at
/home/kares/workspace/oss/jrjackson/pkg/rubygems-test/gems/jar-dependencies-0.4.1/lib/jars/installer.rb:174
[INFO]                       <top> at -e:1
[INFO]
------------------------------------------------------------------------
[INFO] BUILD FAILURE
[INFO]
------------------------------------------------------------------------

```