### PR TITLE
Bump jackson dependency version to v2.14.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,10 +29,10 @@ represents your custom object.
 
 11th May 2014 - Added to_time method call for Ruby object serialization
 
-26th October 2013 - Added support to serialize arbitrary (non JSON datatypes)
+26th October 2013 - Added support to serialize arbitrary (non JSON data types)
 ruby objects.  Normally the toJava internal method is called, but additionally
 to_h, to_hash, to_a and finally to_json are tried.  Be aware that the to_json
-method might invoke a new selialization session (i.e. it may use the JSON gem)
+method might invoke a new serialization session (i.e. it may use the JSON gem)
 and impact performance.
 
 ***
@@ -43,7 +43,7 @@ and impact performance.
 JrJackson::Json.load(string, options) -> hash like object
       aliased as parse
 ```
-By default the load method will return Ruby objects (Hashes have string keys).
+By default, the load method will return Ruby objects (Hashes have string keys).
 The options hash respects three symbol keys
 
 + :symbolize_keys
@@ -89,6 +89,16 @@ There are four Ruby sub modules of the JrJackson module
 ```JrJackson::Java```, this is used by the external facade, you should use this directly. It returns Java objects e.g. ArrayList, HashMap, BigDecimal, BigInteger, Long, Float and String, JRuby wraps (mostly) them in a JavaProxy Ruby object.
 
 ***
+
+#### How to build the `jrjackson`?
+
+The library requires maven and [ruby-maven]((https://github.com/jruby/ruby-maven)) libraries.
+Make sure to install the maven depending on your system (ex.: `brew install maven` on macOS) and also install ruby-maven with `gem install ruby-maven`.
+Note that, recent builds showed old maven versions failed and succeeded with `3.8.7` version.
+
+Run `rake && rake test` to build and test the `jrjackson`.
+
+To build the local gem to test against your platform, use `gem build jrjackson.gemspec` command.
 
 #### Benchmarks
 

--- a/changelog.md
+++ b/changelog.md
@@ -1,5 +1,5 @@
 v0.4.17
-  Bump jackson and jackson-databind to v2.14.0
+  Bump jackson and jackson-databind to v2.13.4.2
 
 v0.4.16
   Publish v0.4.15 again without world writable files

--- a/changelog.md
+++ b/changelog.md
@@ -1,5 +1,5 @@
 v0.4.17
-  Bump jackson and jackson-databind to v2.13.4.2
+  Bump jackson and jackson-databind to v2.14.1
 
 v0.4.16
   Publish v0.4.15 again without world writable files

--- a/changelog.md
+++ b/changelog.md
@@ -1,3 +1,6 @@
+v0.4.17
+  Bump jackson and jackson-databind to v2.14.0
+
 v0.4.16
   Publish v0.4.15 again without world writable files
 

--- a/lib/jrjackson/build_info.rb
+++ b/lib/jrjackson/build_info.rb
@@ -5,7 +5,7 @@ module JrJackson
     end
 
     def self.release_date
-      '2023-01-14'
+      '2023-01-17'
     end
 
     def self.files
@@ -13,11 +13,11 @@ module JrJackson
     end
 
     def self.jackson_version
-      '2.13.4.2'
+      '2.14.1'
     end
 
     def self.jackson_databind_version
-      '2.13.4.2'
+      '2.14.1'
     end
 
     def self.jar_version

--- a/lib/jrjackson/build_info.rb
+++ b/lib/jrjackson/build_info.rb
@@ -13,11 +13,11 @@ module JrJackson
     end
 
     def self.jackson_version
-      '2.14.0'
+      '2.13.4.2'
     end
 
     def self.jackson_databind_version
-      '2.14.0'
+      '2.13.4.2'
     end
 
     def self.jar_version

--- a/lib/jrjackson/build_info.rb
+++ b/lib/jrjackson/build_info.rb
@@ -1,11 +1,11 @@
 module JrJackson
   module BuildInfo
     def self.version
-      '0.4.16'
+      '0.4.17'
     end
 
     def self.release_date
-      '2022-07-08'
+      '2023-01-14'
     end
 
     def self.files
@@ -13,15 +13,15 @@ module JrJackson
     end
 
     def self.jackson_version
-      '2.13.3'
+      '2.14.0'
     end
 
     def self.jackson_databind_version
-      '2.13.3'
+      '2.14.0'
     end
 
     def self.jar_version
-      '1.2.33'
+      '1.2.34'
     end
 
     private

--- a/test/jrjackson_test.rb
+++ b/test/jrjackson_test.rb
@@ -339,7 +339,7 @@ class JrJacksonTest < Test::Unit::TestCase
 
     time = Time.new(2014,6,10,18,18,40, "-04:00")
     # using date_format option
-    assert_equal "{\"time\":\"2014-06-10\"}", JrJackson::Json.dump({"time" => time}, :date_format => "yyyy-MM-dd")
+    assert_equal "{\"time\":\"2014-06-10\"}", JrJackson::Json.dump({"time" => time}, :date_format => "yyyy-MM-dd", :timezone => "UTC")
     assert_match(/\{"time"\:"\d{4}-\d\d-\d\dT\d\d:\d\d:\d\d\.\d{3}[+-]\d{4}"\}/, JrJackson::Json.dump({"time" => time}, :date_format => "yyyy-MM-dd'T'HH:mm:ss.SSSZ"))
   end
 


### PR DESCRIPTION
Logstash needs to update `jackson` and `jackson-databind` dependencies through `jrjackson`.

- Closes: https://github.com/elastic/logstash/issues/14672