### PR TITLE
Prepare a 0.5.2 release and guard against incomplete gem publish

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -18,11 +18,23 @@ task :compile do
   RubyMaven.exec('prepare-package')
   # after packaging the jrjackson-x.y.z.jar vendor jar dependencies
   Rake::Task['vendor_jars'].invoke
+  Rake::Task['verify_generated_files'].invoke
 end
 
 task :vendor_jars do
   require 'jars/installer'
   Jars::Installer.vendor_jars!
+end
+
+# Fail the build if a file the gemspec lists is missing on disk. This stops a
+# broken gem from shipping, as happened with 0.5.1.
+task :verify_generated_files do
+  $LOAD_PATH.unshift(File.expand_path('lib', __dir__))
+  require 'jrjackson/build_info'
+  missing = JrJackson::BuildInfo.files.reject { |f| File.file?(f) }
+  unless missing.empty?
+    raise "These files are listed in the gemspec but missing after compile #{missing.join(', ')}"
+  end
 end
 
 desc "Clean build"

--- a/changelog.md
+++ b/changelog.md
@@ -1,8 +1,7 @@
 v0.5.2
-  Fix packaging: the generated lib/jrjackson_jars.rb shim was omitted from the
-    v0.5.1 gem, making it fail to load with `LoadError: cannot load such file --
-    jrjackson_jars`. Guard generated_files so a missing generated file now fails
-    the build instead of shipping a broken gem.
+  Fix packaging so the generated lib/jrjackson_jars.rb is included in the gem
+  List generated files explicitly instead of using Dir.glob so they are packaged even when generated after the gemspec is evaluated
+  Add a build step that fails when a file listed in the gemspec is missing
 
 v0.5.1
   Upgrade jackson and jackson-databind to v2.21.4

--- a/changelog.md
+++ b/changelog.md
@@ -1,3 +1,12 @@
+v0.5.2
+  Fix packaging: the generated lib/jrjackson_jars.rb shim was omitted from the
+    v0.5.1 gem, making it fail to load with `LoadError: cannot load such file --
+    jrjackson_jars`. Guard generated_files so a missing generated file now fails
+    the build instead of shipping a broken gem.
+
+v0.5.1
+  Upgrade jackson and jackson-databind to v2.21.4
+
 v0.5.0
   Upgrade jackson and jackson-databind to v2.21.2
   Require JRuby 9.4.14.0 and Java 11 toolchain for builds

--- a/lib/jrjackson/build_info.rb
+++ b/lib/jrjackson/build_info.rb
@@ -37,8 +37,11 @@ module JrJackson
       %w(pom.xml lib/jrjackson_jars.rb)
     end
 
+    # Exclude jars from the glob. They are listed with their exact versions in
+    # generated_jar_files, so leftover jars from an older version are not
+    # packaged.
     def self.repo_files
-      Dir["lib/**/*"].select{ |f| File.file? f } + ["README.md", "jrjackson.gemspec", ]
+      Dir["lib/**/*"].select{ |f| File.file?(f) && !f.end_with?(".jar") } + ["README.md", "jrjackson.gemspec", ]
     end
 
     def self.generated_jar_files

--- a/lib/jrjackson/build_info.rb
+++ b/lib/jrjackson/build_info.rb
@@ -1,11 +1,11 @@
 module JrJackson
   module BuildInfo
     def self.version
-      '0.5.1'
+      '0.5.2'
     end
 
     def self.release_date
-      '2026-06-26'
+      '2026-07-07'
     end
 
     def self.files
@@ -31,7 +31,14 @@ module JrJackson
     private
 
     def self.generated_files
-      Dir.glob( %w(pom.xml lib/jrjackson_jars.rb) )
+      files = %w(pom.xml lib/jrjackson_jars.rb)
+      missing = files.reject { |f| File.file?(f) }
+      unless missing.empty?
+        raise "jrjackson packaging error: generated file(s) missing at build time: " \
+              "#{missing.join(', ')}. Run `rake vendor_jars` (or `rake compile`) to " \
+              "regenerate them before building the gem."
+      end
+      files
     end
 
     def self.repo_files

--- a/lib/jrjackson/build_info.rb
+++ b/lib/jrjackson/build_info.rb
@@ -30,15 +30,11 @@ module JrJackson
 
     private
 
+    # Use an explicit list, not Dir.glob. The gemspec is evaluated at Rakefile
+    # load time, before rake compile regenerates these files, so a glob would
+    # drop them.
     def self.generated_files
-      files = %w(pom.xml lib/jrjackson_jars.rb)
-      missing = files.reject { |f| File.file?(f) }
-      unless missing.empty?
-        raise "jrjackson packaging error: generated file(s) missing at build time: " \
-              "#{missing.join(', ')}. Run `rake vendor_jars` (or `rake compile`) to " \
-              "regenerate them before building the gem."
-      end
-      files
+      %w(pom.xml lib/jrjackson_jars.rb)
     end
 
     def self.repo_files


### PR DESCRIPTION
This commit prepares a 0.5.2 release to fix the incomplete gem publish for 0.5.1. I have also included a guard against this happening in the future.

Closes https://github.com/guyboertje/jrjackson/issues/102